### PR TITLE
Rewind Unpause Configuration & Configurable Rewind Bind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-.vs/
-build/
-plugins/
-version.h
-*.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vs/
+build/
+plugins/
+version.h
+*.vcxproj

--- a/CheckpointPlugin.cpp
+++ b/CheckpointPlugin.cpp
@@ -121,21 +121,21 @@ void CheckpointPlugin::onLoad()
 
 	// Register CVars for action thresholds and enable/disable toggles
 	cvarManager->registerCvar("enable_throttle_unpause", "1", "Enable throttle to unpause", true, true, 0, true, 1, true);
-	cvarManager->registerCvar("throttle_threshold", "0.85", "Threshold for throttle to unpause", true, true, 0, true, 1, true);
+	cvarManager->registerCvar("throttle_threshold", "0.1", "Threshold for throttle to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_steer_unpause", "0", "Enable steering to unpause", true, true, 0, true, 1, true);
 	cvarManager->registerCvar("steer_threshold", "0.1", "Threshold for steering to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_pitch_unpause", "1", "Enable pitch to unpause", true, true, 0, true, 1, true);
-	cvarManager->registerCvar("pitch_threshold", "0.4", "Threshold for pitch to unpause", true, true, 0, true, 1, true);
+	cvarManager->registerCvar("pitch_threshold", "0.80", "Threshold for pitch to unpause", true, true, 0, true, 1, true);
 
-	cvarManager->registerCvar("enable_yaw_unpause", "1", "Enable yaw to unpause", true, true, 0, true, 1, true);
-	cvarManager->registerCvar("yaw_threshold", "0.4", "Threshold for yaw to unpause", true, true, 0, true, 1, true);
+	cvarManager->registerCvar("enable_yaw_unpause", "0", "Enable yaw to unpause", true, true, 0, true, 1, true);
+	cvarManager->registerCvar("yaw_threshold", "0.1", "Threshold for yaw to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_roll_unpause", "1", "Enable roll to unpause", true, true, 0, true, 1, true);
 	cvarManager->registerCvar("roll_threshold", "0.1", "Threshold for roll to unpause", true, true, 0, true, 1, true);
 
-	cvarManager->registerCvar("rewind_threshold", "0.05", "Threshold for steering to unpause", true, true, 0, true, 1, true);
+	cvarManager->registerCvar("rewind_threshold", "0.05", "Threshold for the rewind input to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_handbrake_unpause", "1", "Enable handbrake to unpause", true, true, 0, true, 1, true);
 	cvarManager->registerCvar("enable_jump_unpause", "1", "Enable jump to unpause", true, true, 0, true, 1, true);
@@ -144,7 +144,7 @@ void CheckpointPlugin::onLoad()
 
 
 	cvarManager->registerCvar("rewind_axis", "steer", "Input used for rewinding (steer, throttle, pitch, yaw, roll)");
-	cvarManager->registerCvar("matching_axis", "none", "Your bind that is on the same stick as the rewind input");
+	cvarManager->registerCvar("matching_axis", "pitch", "Your bind that is on the same stick as the rewind input");
 
 	// original cvars
 	cvarManager->registerCvar("cpt_allow_delete_all", "0", "Enables the delete all button", false, true, 0, true, 1, false);
@@ -716,6 +716,10 @@ bool CheckpointPlugin::rewind(ServerWrapper sw) {
 	const float rewindThreshold = cvarManager->getCvar("rewind_threshold").getFloatValue();
 	if (abs(rewindInput) < rewindThreshold) {
 		return true; // Ignoring input; apply state.
+	} else if (isAtCheckpoint) {
+		log("checkpoint active, unpausing game instead of rewinding");
+		setFrozen(false, false);
+		return false;  // Unpausing the game due to checkpoint.
 	}
 
 	rewindState.deleting = false;

--- a/CheckpointPlugin.cpp
+++ b/CheckpointPlugin.cpp
@@ -711,11 +711,15 @@ bool CheckpointPlugin::rewind(ServerWrapper sw) {
 	}
 	rewindState.buttonsDown = buttonsDown;
 
-	// Determine how much to rewind / advance time.
-	if (abs(rewindInput) < .05f) { // Ignore slight input; keep current game state.
+	
+	// Ignore slight input; keep current game state.
+	if (abs(rewindInput) < cvarManager->getCvar("rewind_threshold").getFloatValue()) {
 		return true; // Ignoring input; apply state.
 	}
+
 	rewindState.deleting = false;
+
+	// Determine how much to rewind / advance time.
 	if (rewindInput< -.95 && rewindState.holdingFor <= 0) {
 		rewindState.holdingFor -= elapsed;
 	} else if (rewindInput > .95 && rewindState.holdingFor >= 0) {
@@ -731,11 +735,6 @@ bool CheckpointPlugin::rewind(ServerWrapper sw) {
 	// if you are trying to use the matching axis more than the rewind axis
 	// and you've haven't hit the threshold to unpause, don't rewind
 	if ((matchingAxis != "None" && fabs(matchingInput) > fabs(rewindInput))) {
-		deltaElapsed = 0;
-	}
-
-	// ensure minimum rewind value
-	if (fabs(rewindInput) < cvarManager->getCvar("rewind_threshold").getFloatValue()) {
 		deltaElapsed = 0;
 	}
 

--- a/CheckpointPlugin.cpp
+++ b/CheckpointPlugin.cpp
@@ -121,19 +121,21 @@ void CheckpointPlugin::onLoad()
 
 	// Register CVars for action thresholds and enable/disable toggles
 	cvarManager->registerCvar("enable_throttle_unpause", "1", "Enable throttle to unpause", true, true, 0, true, 1, true);
-	cvarManager->registerCvar("throttle_threshold", "0.1", "Threshold for throttle to unpause", true, true, 0, true, 1, true);
+	cvarManager->registerCvar("throttle_threshold", "0.85", "Threshold for throttle to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_steer_unpause", "0", "Enable steering to unpause", true, true, 0, true, 1, true);
 	cvarManager->registerCvar("steer_threshold", "0.1", "Threshold for steering to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_pitch_unpause", "1", "Enable pitch to unpause", true, true, 0, true, 1, true);
-	cvarManager->registerCvar("pitch_threshold", "0.1", "Threshold for pitch to unpause", true, true, 0, true, 1, true);
+	cvarManager->registerCvar("pitch_threshold", "0.4", "Threshold for pitch to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_yaw_unpause", "1", "Enable yaw to unpause", true, true, 0, true, 1, true);
-	cvarManager->registerCvar("yaw_threshold", "0.1", "Threshold for yaw to unpause", true, true, 0, true, 1, true);
+	cvarManager->registerCvar("yaw_threshold", "0.4", "Threshold for yaw to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_roll_unpause", "1", "Enable roll to unpause", true, true, 0, true, 1, true);
 	cvarManager->registerCvar("roll_threshold", "0.1", "Threshold for roll to unpause", true, true, 0, true, 1, true);
+
+	cvarManager->registerCvar("rewind_threshold", "0.2", "Threshold for steering to unpause", true, true, 0, true, 1, true);
 
 	cvarManager->registerCvar("enable_handbrake_unpause", "1", "Enable handbrake to unpause", true, true, 0, true, 1, true);
 	cvarManager->registerCvar("enable_jump_unpause", "1", "Enable jump to unpause", true, true, 0, true, 1, true);
@@ -660,9 +662,6 @@ bool CheckpointPlugin::rewind(ServerWrapper sw) {
 		}
 		if (cvarManager->getCvar(unpauseSetting).getBoolValue()) {
 			float effectiveThreshold = cvarManager->getCvar(thresholdSetting).getFloatValue();
-			if (axis == matchingAxis) {
-				effectiveThreshold = 0.9; // TODO customizable
-			}
 			if (fabs(axisValue) > effectiveThreshold) {
 				buttonsDown |= buttonBit;
 			}
@@ -731,7 +730,12 @@ bool CheckpointPlugin::rewind(ServerWrapper sw) {
 
 	// if you are trying to use the matching axis more than the rewind axis
 	// and you've haven't hit the threshold to unpause, don't rewind
-	if ((matchingAxis != "None" && fabs(matchingInput) > fabs(rewindInput)) || fabs(rewindInput) < 0.1) { // TODO customizable
+	if ((matchingAxis != "None" && fabs(matchingInput) > fabs(rewindInput))) {
+		deltaElapsed = 0;
+	}
+
+	// ensure minimum rewind value
+	if (fabs(rewindInput) < cvarManager->getCvar("rewind_threshold").getFloatValue()) {
 		deltaElapsed = 0;
 	}
 

--- a/CheckpointPlugin.cpp
+++ b/CheckpointPlugin.cpp
@@ -660,8 +660,8 @@ bool CheckpointPlugin::rewind(ServerWrapper sw) {
 		}
 		if (cvarManager->getCvar(unpauseSetting).getBoolValue()) {
 			float effectiveThreshold = cvarManager->getCvar(thresholdSetting).getFloatValue();
-			if ((axis == matchingAxis) && isAtCheckpoint) {
-				effectiveThreshold = 0.9; 
+			if (axis == matchingAxis) {
+				effectiveThreshold = 0.9; // TODO customizable
 			}
 			if (fabs(axisValue) > effectiveThreshold) {
 				buttonsDown |= buttonBit;
@@ -731,7 +731,7 @@ bool CheckpointPlugin::rewind(ServerWrapper sw) {
 
 	// if you are trying to use the matching axis more than the rewind axis
 	// and you've haven't hit the threshold to unpause, don't rewind
-	if (matchingAxis != "None" && fabs(matchingInput) > fabs(rewindInput)) {
+	if ((matchingAxis != "None" && fabs(matchingInput) > fabs(rewindInput)) || fabs(rewindInput) < 0.1) { // TODO customizable
 		deltaElapsed = 0;
 	}
 

--- a/SettingsFile.cpp
+++ b/SettingsFile.cpp
@@ -108,6 +108,7 @@ void CheckpointPlugin::writeSettingsFile() {
 8|
 6|Rewind Input Method|rewind_axis|Steer@steer&Throttle@throttle&Pitch@pitch&Yaw@yaw&Roll@roll
 6|Rewind Input Matching Axis Bind|matching_axis|None@none&Steer@steer&Throttle@throttle&Pitch@pitch&Yaw@yaw&Roll@roll
+4|Rewind Threshold|rewind_threshold|0.0|1.0
 8|
 9|Rewind Unpause Actions Configuration:
 1|Throttle Unpauses|enable_throttle_unpause

--- a/SettingsFile.cpp
+++ b/SettingsFile.cpp
@@ -105,6 +105,25 @@ void CheckpointPlugin::writeSettingsFile() {
 9| Freeplay Checkpoint
 9| Bugs/Feature Requests: github.com/NitrOP7674 -or- on Discord: https://discord.gg/SPBxrtfrZw
 9| ** Please make sure to read the README first! **
+8|
+6|Rewind Input Method|rewind_axis|Steer@steer&Throttle@throttle&Pitch@pitch&Yaw@yaw&Roll@roll
+6|Rewind Input Matching Axis Bind|matching_axis|None@none&Steer@steer&Throttle@throttle&Pitch@pitch&Yaw@yaw&Roll@roll
+8|
+9|Rewind Unpause Actions Configuration:
+1|Throttle Unpauses|enable_throttle_unpause
+4|Throttle Threshold|throttle_threshold|0.0|1.0
+1|Steer Unpauses|enable_steer_unpause
+4|Steer Threshold|steer_threshold|0.0|1.0
+1|Pitch Unpauses|enable_pitch_unpause
+4|Pitch Threshold|pitch_threshold|0.0|1.0
+1|Yaw Unpauses|enable_yaw_unpause
+4|Yaw Threshold|yaw_threshold|0.0|1.0
+1|Roll Unpauses|enable_roll_unpause
+4|Roll Threshold|roll_threshold|0.0|1.0
+1|Handbrake Unpauses|enable_handbrake_unpause
+1|Jump Unpauses|enable_jump_unpause
+1|Boost Unpauses|enable_boost_activate_unpause
+1|Boost Hold Unpauses|enable_boost_hold_unpause
 )";
 	setFile.close();
 	cvarManager->executeCommand("cl_settings_refreshplugins");

--- a/SettingsFile.cpp
+++ b/SettingsFile.cpp
@@ -100,15 +100,10 @@ void CheckpointPlugin::writeSettingsFile() {
 5|History Refresh Rate (ms)|cpt_snapshot_interval|1|10
 9|
 1|Debug -- Show debugging state|cpt_debug
-9|
-9|
-9| Freeplay Checkpoint
-9| Bugs/Feature Requests: github.com/NitrOP7674 -or- on Discord: https://discord.gg/SPBxrtfrZw
-9| ** Please make sure to read the README first! **
 8|
 6|Rewind Input Method|rewind_axis|Steer@steer&Throttle@throttle&Pitch@pitch&Yaw@yaw&Roll@roll
 6|Rewind Input Matching Axis Bind|matching_axis|None@none&Steer@steer&Throttle@throttle&Pitch@pitch&Yaw@yaw&Roll@roll
-4|Rewind Threshold|rewind_threshold|0.0|1.0
+1|Used to prevent accidentally leaving rewind mode due to slight input on the stick's other axis
 8|
 9|Rewind Unpause Actions Configuration:
 1|Throttle Unpauses|enable_throttle_unpause
@@ -121,10 +116,10 @@ void CheckpointPlugin::writeSettingsFile() {
 4|Yaw Threshold|yaw_threshold|0.0|1.0
 1|Roll Unpauses|enable_roll_unpause
 4|Roll Threshold|roll_threshold|0.0|1.0
-1|Handbrake Unpauses|enable_handbrake_unpause
-1|Jump Unpauses|enable_jump_unpause
-1|Boost Unpauses|enable_boost_activate_unpause
-1|Boost Hold Unpauses|enable_boost_hold_unpause
+8|
+9| Freeplay Checkpoint
+9| Bugs/Feature Requests: github.com/NitrOP7674 -or- on Discord: https://discord.gg/SPBxrtfrZw
+9| ** Please make sure to read the README first! **
 )";
 	setFile.close();
 	cvarManager->executeCommand("cl_settings_refreshplugins");


### PR DESCRIPTION
# screenshots
![image](https://github.com/NitrOP7674/FreeplayCheckpoint/assets/36829176/c8bcb762-3197-453d-8e07-5f343ab84086)



# description
- adds configuration for rewind unfreeze actions. users can enable/disable certain actions from unpausing rewind, as well as set custom thresholds for steer/pitch/throttle/roll.
- adds configuration for the `Rewind Input Method` allowing uses to select from `Steer/Throttle/Pitch/Roll` as the analogue input to control the game state. i also added a threshold for this input

# original issue
https://github.com/NitrOP7674/FreeplayCheckpoint/issues/40
https://github.com/NitrOP7674/FreeplayCheckpoint/issues/37

# considerations
we should agree on default values
we should agree where this list appears on the settings page. currently it is at the top
